### PR TITLE
openEMS.rb: use Qt6 in Homebrew, fix #108

### DIFF
--- a/openEMS.rb
+++ b/openEMS.rb
@@ -11,7 +11,7 @@ class Openems < Formula
   end
 
   depends_on "cmake" => :build
-  depends_on "qt@5"
+  depends_on "qt@6"
   depends_on "vtk"
   depends_on "tinyxml"
   depends_on "hdf5"


### PR DESCRIPTION
Most packages in Homebrew are now built using Qt6 instead of Qt5, including VTK. Using Qt5 as a dependency in openEMS causes the following build failure due to version conflict (as reported in thliebig/QCSXCAD#13 and #108):

    CMake Error: The INTERFACE_QT_MAJOR_VERSION property of "Qt6::OpenGL" does
    not agree with the value of QT_MAJOR_VERSION already determined
    for "QCSXCAD".

This commit fixes the problem by switching to Qt6 in the Homebrew package.

This patchset should only be merged after merging thliebig/QCSXCAD#14 and thliebig/AppCSXCAD#10.