### PR TITLE
Fix Homebrew SDK path build issue

### DIFF
--- a/openEMS.rb
+++ b/openEMS.rb
@@ -21,6 +21,7 @@ class Openems < Formula
   depends_on "boost"
 
   def install
+    ENV["SDKROOT"] = MacOS.sdk_path
     system "cmake", ".", *std_cmake_args
     system "make"
     # install is handled by ExternalProject_Add


### PR DESCRIPTION
Homebrew installation stopped working for me around the time macOS Ventura was released. This seems to be a problem related to macOS SDK versions/paths not being properly passed to CMake. Homebrew provides (through its `std_cmake_args`) the top-level CMake with, for example, `-DCMAKE_OSX_SYSROOT=/Library/Developer/CommandLineTools/SDKs/MacOSX13.sdk`. This option is not passed through to the sub-projects since the passed-through arguments are manually specified in `CMakeLists.txt`:

```cmake
ExternalProject_Add(QCSXCAD
    DEPENDS     CSXCAD
    SOURCE_DIR  ${PROJECT_SOURCE_DIR}/QCSXCAD
    CMAKE_ARGS  -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TOOLCHAIN_FILE} -DCSXCAD_ROOT_DIR=${CMAKE_INSTALL_PREFIX} -DCMAKE_INSTALL_PREFIX=${CMAKE_INSTALL_PREFIX}
)
```

The cleanest solution seems to be to set `CMAKE_OSX_SYSROOT` using the `SDKROOT` environment variable, which will be picked up by all the sub-CMakes and [should be equivalent](https://cmake.org/cmake/help/latest/variable/CMAKE_OSX_SYSROOT.html).

This should fix the latest problem brought up in #108.