### PR TITLE
Add Python bindings to Brew formula

### DIFF
--- a/doc-src/install/package.rst
+++ b/doc-src/install/package.rst
@@ -86,8 +86,9 @@ Setup Python Interfaces
 
 - **Optional**: Build Python libraries.
 
-Unfortunately, currently Python modules are not automatically installed,
-they need manual installation.
+If you install openEMS with Homebrew, the Python libraries will be automatically installed unless `--without-python@3` is passed.
+
+If you prefer to build them manually, follow the following instructions.
 
 First, install the needed dependencies...
 
@@ -106,21 +107,23 @@ cloned git code:
 
 .. code-block:: console
 
-    cd CSXCAD
-    cd python
-    pip3 install . --user
+    cd CSXCAD/python
+    BREW=$(brew --prefix)
+    python3 setup.py build_ext -I$BREW/include -L$BREW/lib -R$BREW/lib
+    python3 setup.py install
 
-    cd ..
+    cd ../..
 
 2. Build openEMS's Python extension:
 
 .. code-block:: console
 
-    cd openEMS
-    cd python
-    pip3 install . --user
+    cd openEMS/python
+    BREW=$(brew --prefix)
+    python3 setup.py build_ext -I$BREW/include -L$BREW/lib -R$BREW/lib
+    python3 setup.py install
 
-    cd ..
+    cd ../..
 
 Check Installation
 ~~~~~~~~~~~~~~~~~~~
@@ -150,9 +153,6 @@ Updating
 .. code-block:: console
 
     brew upgrade --fetch-HEAD openems
-
-If Python modules are used, they need to be reinstalled (in case that
-a module has been updated).
 
 .. _openEMS_win: https://github.com/thliebig/openEMS-Project/releases
 .. _Homebrew: https://brew.sh

--- a/openEMS.rb
+++ b/openEMS.rb
@@ -3,6 +3,8 @@
 require "formula"
 
 class Openems < Formula
+  include Language::Python::Virtualenv
+
   desc "Electromagnetic field solver using the FDTD method"
   homepage "https://www.openems.de"
 
@@ -19,12 +21,48 @@ class Openems < Formula
   depends_on "mpfr"
   depends_on "cgal"
   depends_on "boost"
+  depends_on "python@3" => :recommended
+
+  if build.with? "python@3"
+    depends_on "cython"
+    depends_on "numpy"
+    depends_on "python-matplotlib"
+  end
 
   def install
     ENV["SDKROOT"] = MacOS.sdk_path
     system "cmake", ".", *std_cmake_args
     system "make"
     # install is handled by ExternalProject_Add
+
+    if build.with? "python@3"
+      # Get python 3 sub-version we are currently using (3.x)
+      python_version = Formula["python@3"].version.to_s.split(".")[0..1].join(".")
+      python = "python#{python_version}"
+
+      # Install non-bottled dependencies into a virtual environment
+      venv = virtualenv_create(libexec, "python3")
+      venv.pip_install "h5py"
+
+      # Create .pth file to reference packages in venv
+      (lib/"#{python}/site-packages/homebrew-openems-dependencies.pth").write <<~EOS
+        #{libexec}/lib/#{python}/site-packages
+      EOS
+
+      # Use keg-only cython
+      ENV.prepend_path "PYTHONPATH", "#{Formula["cython"].libexec}/lib/#{python}/site-packages"
+
+      # Build and install bindings
+      cd "CSXCAD/python" do
+        system Formula["python@3"].opt_bin/"python3", "setup.py", "build_ext", "-I", include, "-L", lib, "-R", lib, "-j", ENV.make_jobs
+        system Formula["python@3"].opt_bin/"python3", *Language::Python.setup_install_args(prefix)
+      end
+
+      cd "openEMS/python" do
+        system Formula["python@3"].opt_bin/"python3", "setup.py", "build_ext", "-I", include, "-L", lib, "-R", lib, "-j", ENV.make_jobs
+        system Formula["python@3"].opt_bin/"python3", *Language::Python.setup_install_args(prefix)
+      end
+    end
   end
 
 end


### PR DESCRIPTION
Fixes https://github.com/thliebig/openEMS/issues/135 and fixes https://github.com/thliebig/CSXCAD/issues/38.

Python bindings are now installed by default (but can be disabled) when installing with Homebrew.

Currently a draft PR because
 * Is this really the best way to install Python libraries? I really don't like the hard-coded versions, but that seems to be suggested by [their guide](https://docs.brew.sh/Python-for-Formula-Authors) and it makes installing `matplotlib` extremely complicated because of all its dependencies. [Pending discussion here.](https://github.com/orgs/Homebrew/discussions/5001) An alternative would be to have the end user install packages with `pip` themselves but that seems counterproductive.
 * Should `matplotlib` be installed? Currently only `cython` (from bottle), `numpy` (from bottle), and `h5py` (from source) are installed. Those are the only required libraries for the bindings to work, but `matplotlib` is used in tutorials. It looks like `matplotlib` would need to be installed from source, which would make the install take forever and would significantly complicate things.
 * Given the fixed version of the packages, should a Python 3 sub-version be pinned (like 3.12) instead of just specifying the latest Python 3?
 * When uninstalled via brew, `openEMS` and `CSXCAD` remain as weird ghost empty packages that can be imported but don't contain anything.