### PR TITLE
Workaround for CMake not finding HDF5

### DIFF
--- a/doc-src/install/manual.rst
+++ b/doc-src/install/manual.rst
@@ -138,11 +138,12 @@ Troubleshooting
 
 .. _manual_freebsd_workaround_src:
 
-FreeBSD
+HDF5 Not Found
 ^^^^^^^^^
 
 On FreeBSD, the default CMake has a bug, causing it unable to find
 HDF5 for CSXCAD and openEMS (the version in FreeBSD Ports is fine).
+This can also happen on macOS.
 
 .. code-block:: console
 

--- a/openEMS.rb
+++ b/openEMS.rb
@@ -8,9 +8,7 @@ class Openems < Formula
   desc "Electromagnetic field solver using the FDTD method"
   homepage "https://www.openems.de"
 
-  head do
-    url "https://github.com/thliebig/openEMS-Project.git"
-  end
+  head "https://github.com/thliebig/openEMS-Project.git", branch: "master"
 
   depends_on "cmake" => :build
   depends_on "qt@6"
@@ -27,9 +25,17 @@ class Openems < Formula
     depends_on "cython"
     depends_on "numpy"
     depends_on "python-matplotlib"
+    depends_on "python-setuptools"
   end
 
   def install
+    # Workaround for CMake HDF5 bug: https://gitlab.kitware.com/cmake/cmake/-/issues/25358
+    %w[openEMS/CMakeLists.txt CSXCAD/CMakeLists.txt AppCSXCAD/CMakeLists.txt].each do |file|
+      inreplace file do |s|
+        s.gsub! "find_package(HDF5 1.8 ", "find_package(HDF5 "
+      end
+    end
+
     ENV["SDKROOT"] = MacOS.sdk_path
     system "cmake", ".", *std_cmake_args
     system "make"


### PR DESCRIPTION
Fixes #197 

On macOS (and also FreeBSD according to the [docs here](https://docs.openems.de/install/manual.html#troubleshooting)), CMake can't find HDF5 when a minimum version number is specified. It's been reported on the CMake bug tracker: https://gitlab.kitware.com/cmake/cmake/-/issues/25358

But for now it's breaking the Homebrew build, so I added a patch that will remove the 1.8 minimum version dependency from the CMakeLists.txt files before building. Homebrew installs the latest version of HDF5, and version 1.8 is 17 years old, so I don't imagine that version check would come into play under these circumstances anyways.

Also added `python-setuptools` to the dependency list which is now required.