### PR TITLE
Add --help, --verbose, --njobs flags to update_openEMS.sh

### DIFF
--- a/update_openEMS.sh
+++ b/update_openEMS.sh
@@ -5,6 +5,8 @@
 # Compiling hyp2mat may require installing the following packages:
 # apt-get install gengetopt help2man groff pod2pdf bison flex libhpdf-dev libtool
 
+set -o pipefail
+
 EOK=0
 EINVAL=22
 


### PR DESCRIPTION
This is entirely a QOL PR. Feel free to knock it back if you don't feel it fits with the project, or let me know if you only want parts of it.

New flags:
 * --help, show help message
 * --verbose, output to screeen as well as logfile
 * --njobs, set number of jobs for multi-core machines

Updated behavior:
 * Now automatically selects optimal number for cores for building.
 * Install path can now be specified anywhere in arguments, not just as the first argument