### PR TITLE
Fix CI/CD builds on Ubuntu 14.04, macOS, and FreeBSD

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -297,7 +297,51 @@ jobs:
         run: |
           echo 'export CXXFLAGS="-std=c++11"' >> ~/.zprofile
 
-          brew install cmake boost tinyxml hdf5 cgal vtk python3 octave
+          brew install cmake boost hdf5 cgal vtk python3 octave
+
+          # TinyXML has been disabled by Homebrew at it's unmaintained
+          # since 2011, TinyXML2 is not API-compatible. As a stop-gap,
+          # build from source.
+          #
+          # -L: follow redirect, REQUIRED!
+          curl -L https://sourceforge.net/projects/tinyxml/files/tinyxml/2.6.2/tinyxml_2_6_2.tar.gz -o tinyxml-2.6.2.tar.gz
+          tar -xf tinyxml-2.6.2.tar.gz
+          cd tinyxml
+
+          # The first patch enforces use of stl strings, rather than a custom string type.
+          # The second patch is a fix for incorrect encoding of elements with special characters
+          # The third and fourth patches are security fixes.
+          #
+          # -L: follow redirect, REQUIRED!
+          # -O: save to disk with an automatic file name.
+          curl -L -O "https://raw.githubusercontent.com/alpinelinux/aports/b1ff376e83eb49c0127b039b3684eccdf9a60694/community/tinyxml/tinyxml-2.6.2-defineSTL.patch"
+          curl -L -O "https://raw.githubusercontent.com/alpinelinux/aports/b1ff376e83eb49c0127b039b3684eccdf9a60694/community/tinyxml/tinyxml-2.6.1-entity.patch"
+          curl -L -O "https://raw.githubusercontent.com/alpinelinux/aports/b1ff376e83eb49c0127b039b3684eccdf9a60694/community/tinyxml/CVE-2021-42260.patch"
+          curl -L -O "https://raw.githubusercontent.com/alpinelinux/aports/b1ff376e83eb49c0127b039b3684eccdf9a60694/community/tinyxml/CVE-2023-34194.patch"
+
+          # The final patch adds a CMakeLists.txt file to build a shared library and provide an install target
+          # submitted upstream as https://sourceforge.net/p/tinyxml/patches/66/
+          curl -L -O "https://gist.githubusercontent.com/scpeters/6325123/raw/cfb079be67997cb19a1aee60449714a1dedefed5/tinyxml_CMakeLists.patch"
+
+          patch -p1 < tinyxml-2.6.2-defineSTL.patch
+          patch -p1 < tinyxml-2.6.1-entity.patch
+          patch -p1 < CVE-2021-42260.patch
+          patch -p1 < CVE-2023-34194.patch
+
+          # You know something is truly deprecated when the patch itself needs
+          # patching! In CMake 4, 3.10 is deprecated and 3.5 has been removed.
+          # use 3.0...3.10 so all of these versions are acceptable as min. version.
+          # (CMake 2 is dropped since openEMS already requires CMake 3, and also
+          # because CMake 2 is too old that it's not even documented anymore)
+          #
+          # https://cmake.org/cmake/help/latest/command/cmake_minimum_required.html
+          sed -i -e "s/cmake_minimum_required(VERSION 2.4.6)/cmake_minimum_required(VERSION 3.0...3.10)/" \
+                    tinyxml_CMakeLists.patch  # -e is not optional in BSD sed
+          patch -p1 < tinyxml_CMakeLists.patch
+
+          mkdir build && cd build
+          cmake ../ -DCMAKE_INSTALL_PREFIX=$HOME/opt
+          make -j`nproc` && make install
 
           # cython is keg-only, which means it was not symlinked into /opt/homebrew,
           # because this formula is mainly used internally by other formulae.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -153,7 +153,9 @@ jobs:
               # Ubuntu 14.04's cython3 package is ancient, install via pip instead
               apt-get install -y python3-pip
 
-              pip3 install cython
+              # Must use Cython 3.0 or lower, since 3.1 uses f-string which is
+              # incompatible with Python 3.4.
+              pip3 install "cython<3.1"
             else
               apt-get install -y libboost-all-dev
               apt-get install -y libcgal-dev

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -251,9 +251,15 @@ jobs:
       - if: ${{ matrix.os.ancient }}
         name: Checkout openEMS-Project.git (legacy system only)
         run: |
-          echo "Clone $GITHUB_REF_NAME from $GITHUB_SERVER_URL/$GITHUB_REPOSITORY.git"
-          git clone -b $GITHUB_REF_NAME --recursive $GITHUB_SERVER_URL/$GITHUB_REPOSITORY.git openEMS-Project
+          echo "Clone $GITHUB_SHA from $GITHUB_SERVER_URL/$GITHUB_REPOSITORY.git"
+          git clone --recursive $GITHUB_SERVER_URL/$GITHUB_REPOSITORY.git openEMS-Project
           cd $GITHUB_WORKSPACE/openEMS-Project
+
+          # force git to fetch all trees, otherwise "git checkout $GITHUB_SHA"
+          # fails with "fatal: reference is not a tree" for Pull Requests
+          git fetch --force $GITHUB_SERVER_URL/$GITHUB_REPOSITORY.git "+refs/heads/*:refs/remotes/origin/*"
+          git fetch --force $GITHUB_SERVER_URL/$GITHUB_REPOSITORY.git "+refs/pull/*/merge:refs/remotes/origin/pr/*"
+          git checkout $GITHUB_SHA
 
       - name: Build and install openEMS
         run: |
@@ -445,9 +451,9 @@ jobs:
                                 # version. FreeBSD 14.2 uses Python 3.11 so
                                 # use "py311-"
 
-            echo "Clone $GITHUB_REF_NAME from $GITHUB_SERVER_URL/$GITHUB_REPOSITORY.git"
+            echo "Clone $GITHUB_SHA from $GITHUB_SERVER_URL/$GITHUB_REPOSITORY.git"
             cd ~/
-            git clone -b $GITHUB_REF_NAME --recursive $GITHUB_SERVER_URL/$GITHUB_REPOSITORY.git openEMS-Project
+            git clone --recursive $GITHUB_SERVER_URL/$GITHUB_REPOSITORY.git openEMS-Project
 
             echo "Build and install openEMS..."
 
@@ -457,6 +463,13 @@ jobs:
             export LDFLAGS="-L$HOME/opt/lib -L/usr/local/lib"
 
             cd ~/openEMS-Project
+
+            # force git to fetch all trees, otherwise "git checkout $GITHUB_SHA"
+            # fails with "fatal: reference is not a tree" for Pull Requests
+            git fetch --force $GITHUB_SERVER_URL/$GITHUB_REPOSITORY.git "+refs/heads/*:refs/remotes/origin/*"
+            git fetch --force $GITHUB_SERVER_URL/$GITHUB_REPOSITORY.git "+refs/pull/*/merge:refs/remotes/origin/pr/*"
+            git checkout $GITHUB_SHA
+
             if bash ./update_openEMS.sh ~/opt --python; then
               cat build_*.log
             else

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,7 +105,7 @@ jobs:
           if grep -q "ID=fedora" /etc/os-release; then
             dnf install -y git
             dnf install -y gcc gcc-c++ cmake git boost-devel tinyxml-devel vtk-devel hdf5-devel \
-                           CGAL-devel vtk-qt octave python3-Cython python3-h5py \
+                           CGAL-devel vtk-qt octave python3-setuptools python3-Cython python3-h5py \
                            python3-matplotlib
           elif grep -q 'ID="almalinux"' /etc/os-release; then
             dnf install -y epel-release
@@ -395,6 +395,7 @@ jobs:
             echo "Install dependencies..."
             sudo pkg install -y bash cmake git boost-libs tinyxml vtk9 hdf5 cgal octave \
                                 qt5 python3 \
+                                py311-setuptools \
                                 py311-cython3 py311-numpy py311-h5py py311-matplotlib
                                 # prefix must match FreeBSD's default python
                                 # version. FreeBSD 14.2 uses Python 3.11 so

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,10 @@
 
 PROJECT(openEMS-Project CXX)
 
-cmake_minimum_required(VERSION 2.8)
+# In CMake 4, 3.10 is deprecated and 3.5 has been removed.
+# use 3.0...3.10 so all of these versions are acceptable as min. version.
+# https://cmake.org/cmake/help/latest/command/cmake_minimum_required.html
+cmake_minimum_required(VERSION 3.0...3.10)
 
 if (CMAKE_TOOLCHAIN_FILE)
     message(STATUS "Using CMAKE_TOOLCHAIN_FILE: " ${CMAKE_TOOLCHAIN_FILE})


### PR DESCRIPTION
This Pull Request contains the following changes. Merging these changes would resolve multiple CI/CD build failures, and also prepare the project for the upcoming CMake 4.0 (only macOS's Homebrew has rolled it out, but it's expected to arrive to more systems in the upcoming years).

## Dependency

The following fparser Pull Request must be merged *before* merging this PR, otherwise CI/CD would still fail on macOS due to the missing fix.

* https://github.com/thliebig/fparser/pull/6
* https://github.com/thliebig/CSXCAD/pull/62
* https://github.com/thliebig/QCSXCAD/pull/18
* https://github.com/thliebig/AppCSXCAD/pull/14
* https://github.com/thliebig/openEMS/pull/183

## CMakeLists.txt: use 3.0...3.10 as minimum version.

In CMake 4, 3.10 is deprecated and 3.5 has been removed. Use 3.0...3.10 so all of these versions are acceptable as minimum version.

## python: enable -std=c++11 on POSIX

The Python module requires at least C++11, otherwise syntax error may occur. C++11 is already the default on most platforms, but not on macOS. Set `-std=c++11` on all POSIX systems to make installation easier.

Close: https://github.com/thliebig/openEMS-Project/issues/304

## CI: fix CI/CD for Pull Requests

In commit https://github.com/thliebig/openEMS-Project/commit/c0c115ab97b2426d73732d76f289517e12351b19 ("CI:
updates and fixes"), the incorrect environmental variable `GITHUB_REF_NAME` is used for checking out branches, This fix is NOT correct - `GITHUB_REF` and `GITHUB_REF_NAME` are not valid branch names for Pull Requests.

The correct commit can always be obtained by:

    # force git to fetch all trees, otherwise "git checkout $GITHUB_SHA"
    # fails with "fatal: reference is not a tree" for Pull Requests
    git fetch --force $GITHUB_SERVER_URL/$GITHUB_REPOSITORY.git "+refs/heads/*:refs/remotes/origin/*"
    git fetch --force $GITHUB_SERVER_URL/$GITHUB_REPOSITORY.git "+refs/pull/*/merge:refs/remotes/origin/pr/*"
    git checkout $GITHUB_SHA

This bug directly affects this Pull Request itself. Without this fix, CI/CD doesn't work for this Pull Request.

## CI: add missing setuptools on Fedora and FreeBSD

setuptools is no longer pulled indirectly in the dependency chain on Fedora and FreeBSD, causing CI/CD build failures. Add this missing package.

## CI: don't use Cython 3.1+ on Ubuntu 14.04.

Cython 3.1+ uses f-string which is incompatible with the old Python 3.4 on Ubuntu 14.04.

## CI: build TinyXML manually on macOS due to deprecation.

On macOS, TinyXML is now deprecated by Homebrew:

> Error: tinyxml has been disabled because it is deprecated upstream! It was disabled on 2025-06-03.

TinyXML has not been updated since 2011, with unfixed security vulnerability, so the deprecation is justified. But TinyXML 2 has a different API, so it's not possible to fix the problem in the short term.

As a workaround, build TinyXML 1 from source manually (with custom patches and fixes collected from Homebrew and AlpineLinux's repos, with modification).

This is a partial fix to:

* https://github.com/thliebig/openEMS-Project/issues/328
* https://github.com/thliebig/openEMS-Project/issues/332

Only manual builds are fixed, the Homebrew packages still need updates (I recommended forking TinyXML's Homebrew's build file, see discussions above). Also, the official documentation also needs to be updated to show the workaround used in the manual build procedure on macOS, currently not done.