### PR TITLE
CI, doc-src: add qt5compat on macOS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -428,7 +428,7 @@ jobs:
           # the command is invalid.
           printf "\n%s\n" "set -euo pipefail" >> ~/.bash_profile
 
-          brew install cmake boost hdf5 cgal vtk octave \
+          brew install cmake boost hdf5 cgal vtk octave qt5compat \
                        python3 \
                        python-setuptools numpy python-matplotlib cython
 

--- a/doc-src/install/requirements.rst
+++ b/doc-src/install/requirements.rst
@@ -660,6 +660,12 @@ macOS
 
       brew install cmake boost hdf5 cgal vtk
 
+- To use AppCSXCAD to visualize 3D models (recommended):
+
+  .. code-block:: bash
+
+      brew install qt5compat
+
 - openEMS also depends on TinyXML, which is unmaintained since 2011 and has
   been removed from Homebrew (TinyXML2 is not API-compatible). As a workaround,
   ``update_openEMS.sh`` will automatically download TinyXML and patches online,


### PR DESCRIPTION
macOS's VTK/Qt is transitioning to Qt 6. Add the required dependency qt5compat on macOS in CI script and documentation to ensure proper installation.

See also: https://github.com/thliebig/AppCSXCAD/pull/15